### PR TITLE
Fixing arguments parameter for the new module cmd

### DIFF
--- a/commands/new.go
+++ b/commands/new.go
@@ -34,7 +34,7 @@ func (a *App) newModuleCmd() *cobra.Command {
 	newModuleCmd := &cobra.Command{
 		Use:   "module <name>",
 		Short: "Create a new Puppet module",
-		Args:  cobra.ExactArgs(1),
+		Args:  cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			forgeUser, _ := cmd.Flags().GetString("forge-user")
 			license, _ := cmd.Flags().GetString("license")


### PR DESCRIPTION
It was set to exactly 1 but it should have been minimum of 1, that has now been fixed.

This fixes #45 