### PR TITLE
Adding support for running bundle via voxbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,7 +287,8 @@ already exist under `pkg/`. An error is returned if it is not found.
 
 Runs validation and linting against the current module. This is a passthrough
 command that shells out to `bundle exec rake validate lint`, so it requires
-a Ruby toolchain and the module's bundled gems to be installed.
+a Ruby toolchain and the module's bundled gems to be installed — or a container
+runner (see [Running through voxbox](#running-through-voxbox)).
 ```
 jig validate [args...]
 ```
@@ -299,7 +300,8 @@ invocation.
 
 Runs the module's unit tests. This is a passthrough command that shells out to
 `bundle exec rake spec`, so it requires a Ruby toolchain and the module's
-bundled gems to be installed.
+bundled gems to be installed — or a container runner (see
+[Running through voxbox](#running-through-voxbox)).
 ```
 jig test unit [args...]
 ```
@@ -311,13 +313,57 @@ invocation.
 
 Synchronises the module's managed files from the module's templates. This is a
 passthrough command that shells out to `bundle exec msync update`, so it
-requires a Ruby toolchain and the module's bundled gems to be installed.
+requires a Ruby toolchain and the module's bundled gems to be installed — or a
+container runner (see [Running through voxbox](#running-through-voxbox)).
 ```
 jig update [args...]
 ```
 
 Any additional arguments are passed through verbatim to the underlying msync
 invocation.
+
+## Running through voxbox
+
+The `validate`, `test unit`, and `update` commands run a Ruby toolchain under
+the hood. By default that is the host's `bundle`, which needs a working
+Ruby/bundler install. Instead, jig can run them inside the
+[voxbox](https://github.com/voxpupuli/voxbox) container, so the only host
+dependency is a container engine. This is especially handy on Windows, where a
+system-wide bundler install is awkward.
+
+Enable it via the `[runner]` section of your config file:
+```toml
+[runner]
+type   = "voxbox"                        # "local" (default) or "voxbox"
+engine = "docker"                        # container engine: "docker" (default) or "podman"
+image  = "ghcr.io/voxpupuli/voxbox:latest"  # container image to run
+```
+
+With `type = "voxbox"`, your module root (the current directory) is mounted at
+`/repo` inside the container and used as the working directory, so the toolchain
+and gems come from the image rather than the host.
+
+The voxbox image's entrypoint is already `bundle exec rake`, so the rake-based
+commands pass their tasks straight through. `jig test unit` runs roughly:
+```bash
+docker run --rm -i -v "$PWD:/repo:Z" -w /repo \
+  ghcr.io/voxpupuli/voxbox:latest spec
+```
+
+`jig update` uses `msync`, which is not a rake task, so it overrides the
+entrypoint to run bundle directly:
+```bash
+docker run --rm -i -v "$PWD:/repo:Z" -w /repo --entrypoint bundle \
+  ghcr.io/voxpupuli/voxbox:latest exec msync update
+```
+
+Each setting can also be supplied through the environment, which overrides the
+config file:
+```bash
+export JIG_RUNNER_TYPE=voxbox
+export JIG_RUNNER_ENGINE=podman
+export JIG_RUNNER_IMAGE=ghcr.io/voxpupuli/voxbox:latest
+```
 
 ## Template Overrides
 
@@ -414,10 +460,19 @@ author         = "John Doe"
 license        = "Apache-2.0"
 forge_token    = "your-forge-token"
 template_dir   = "/path/to/templates"
+
+# Optionally run bundle-backed commands through a container instead of the
+# host's bundler. See "Running through voxbox" above.
+[runner]
+type   = "local"                            # "local" (default) or "voxbox"
+engine = "docker"                           # "docker" (default) or "podman"
+image  = "ghcr.io/voxpupuli/voxbox:latest"
 ```
 
 The config path can be overridden with the `--config` flag or the
-`JIG_CONFIG` environment variable.
+`JIG_CONFIG` environment variable. Individual fields can also be set through
+`JIG_`-prefixed environment variables (e.g. `JIG_FORGE_USERNAME`,
+`JIG_RUNNER_TYPE`), which take precedence over the config file.
 
 ## Contributing
 

--- a/commands/app.go
+++ b/commands/app.go
@@ -2,6 +2,7 @@
 package commands
 
 import (
+	"github.com/avitacco/jig/internal/bundle"
 	"github.com/avitacco/jig/internal/config"
 	"github.com/sirupsen/logrus"
 )
@@ -15,4 +16,25 @@ func NewApp() *App {
 	return &App{
 		Logger: logrus.New(),
 	}
+}
+
+// runner builds the bundle.Runner from the loaded config so the
+// update/test/validate commands can transparently run locally or via voxbox.
+func (a *App) runner() bundle.Runner {
+	return bundle.Runner{
+		Type:   a.Config.Runner.Type,
+		Engine: a.Config.Runner.Engine,
+		Image:  a.Config.Runner.Image,
+	}
+}
+
+// runRake runs a rake task (e.g. spec, validate lint) honouring the runner.
+func (a *App) runRake(args []string) error {
+	return bundle.RunRake(a.runner(), args)
+}
+
+// runBundle runs a raw bundle command (e.g. exec msync update) honouring the
+// runner.
+func (a *App) runBundle(args []string) error {
+	return bundle.RunBundle(a.runner(), args)
 }

--- a/commands/test.go
+++ b/commands/test.go
@@ -2,7 +2,6 @@
 package commands
 
 import (
-	"github.com/avitacco/jig/internal/bundle"
 	"github.com/spf13/cobra"
 )
 
@@ -22,7 +21,7 @@ func (a *App) testUnitCmd() *cobra.Command {
 		Short:              "Run unit tests via rake spec through bundle",
 		DisableFlagParsing: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return bundle.RunBundle(append([]string{"exec", "rake", "spec"}, args...))
+			return a.runRake(append([]string{"spec"}, args...))
 		},
 	}
 }

--- a/commands/update.go
+++ b/commands/update.go
@@ -2,7 +2,6 @@
 package commands
 
 import (
-	"github.com/avitacco/jig/internal/bundle"
 	"github.com/spf13/cobra"
 )
 
@@ -12,7 +11,7 @@ func (a *App) updateCmd() *cobra.Command {
 		Short:              "Run msync update through bundle to sync module files",
 		DisableFlagParsing: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return bundle.RunBundle(append([]string{"exec", "msync", "update"}, args...))
+			return a.runBundle(append([]string{"exec", "msync", "update"}, args...))
 		},
 	}
 }

--- a/commands/validate.go
+++ b/commands/validate.go
@@ -2,7 +2,6 @@
 package commands
 
 import (
-	"github.com/avitacco/jig/internal/bundle"
 	"github.com/spf13/cobra"
 )
 
@@ -12,7 +11,7 @@ func (a *App) validateCmd() *cobra.Command {
 		Short:              "Run rake validate and lint through bundle",
 		DisableFlagParsing: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return bundle.RunBundle(append([]string{"exec", "rake", "validate", "lint"}, args...))
+			return a.runRake(append([]string{"validate", "lint"}, args...))
 		},
 	}
 }

--- a/internal/bundle/bundle.go
+++ b/internal/bundle/bundle.go
@@ -3,6 +3,7 @@ package bundle
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"os/exec"
 )
@@ -11,10 +12,113 @@ import (
 var (
 	execCommand = exec.Command
 	osExit      = os.Exit
+	osGetwd     = os.Getwd
 )
 
-func RunBundle(args []string) error {
-	cmd := execCommand("bundle", args...)
+// Default values for the container runner, mirrored from the config package so
+// the bundle layer can stand on its own (and be tested without importing it).
+const (
+	defaultEngine = "docker"
+	defaultImage  = "ghcr.io/voxpupuli/voxbox:latest"
+)
+
+// Runner describes how a bundle-backed command should be executed. The zero
+// value (or Type "local") runs the host's `bundle` directly; Type "voxbox"
+// runs inside the voxbox container so no system-wide Ruby/bundler is needed.
+//
+// The voxbox image is opinionated: its entrypoint is already
+// `bundle exec rake -f <voxbox Rakefile>` with the workdir at /repo. So rake
+// tasks (RunRake) are passed as bare task names, while raw `bundle` commands
+// (RunBundle) override the entrypoint back to `bundle`.
+type Runner struct {
+	Type   string
+	Engine string
+	Image  string
+}
+
+// RunRake runs the given rake task(s) against the current module. Locally this
+// is `bundle exec rake <args>`; in voxbox it relies on the image's rake
+// entrypoint, passing the task names through.
+func RunRake(r Runner, rakeArgs []string) error {
+	name, args, err := r.resolveRake(rakeArgs)
+	if err != nil {
+		return err
+	}
+	return run(name, args)
+}
+
+// RunBundle runs a raw `bundle <args>` command. Locally that is the host
+// bundle; in voxbox the entrypoint is overridden back to `bundle` (the image
+// otherwise defaults to running rake).
+func RunBundle(r Runner, bundleArgs []string) error {
+	name, args, err := r.resolveBundle(bundleArgs)
+	if err != nil {
+		return err
+	}
+	return run(name, args)
+}
+
+func (r Runner) resolveRake(rakeArgs []string) (string, []string, error) {
+	switch r.Type {
+	case "", "local":
+		return "bundle", append([]string{"exec", "rake"}, rakeArgs...), nil
+	case "voxbox", "container":
+		// The voxbox entrypoint already wraps `bundle exec rake`, so the task
+		// names are the container command.
+		return r.container(nil, rakeArgs)
+	default:
+		return "", nil, unknownTypeErr(r.Type)
+	}
+}
+
+func (r Runner) resolveBundle(bundleArgs []string) (string, []string, error) {
+	switch r.Type {
+	case "", "local":
+		return "bundle", bundleArgs, nil
+	case "voxbox", "container":
+		// Override the image's rake entrypoint so we can invoke bundle directly
+		// (e.g. for `bundle exec msync update`, which is not a rake task).
+		return r.container([]string{"--entrypoint", "bundle"}, bundleArgs)
+	default:
+		return "", nil, unknownTypeErr(r.Type)
+	}
+}
+
+// container builds the engine invocation that mounts the current module at
+// /repo and runs cmd inside the image. extraOpts are passed to the engine
+// before the image name (e.g. --entrypoint).
+func (r Runner) container(extraOpts, cmd []string) (string, []string, error) {
+	cwd, err := osGetwd()
+	if err != nil {
+		return "", nil, fmt.Errorf("could not determine working directory for container runner: %w", err)
+	}
+	engine := r.Engine
+	if engine == "" {
+		engine = defaultEngine
+	}
+	image := r.Image
+	if image == "" {
+		image = defaultImage
+	}
+	// Mount the module at /repo and run there. The :Z label is a no-op on
+	// non-SELinux hosts but required for podman on SELinux systems (the
+	// voxpupuli norm). -i keeps stdin open for prompts.
+	args := []string{"run", "--rm", "-i", "-v", cwd + ":/repo:Z", "-w", "/repo"}
+	args = append(args, extraOpts...)
+	args = append(args, image)
+	args = append(args, cmd...)
+	return engine, args, nil
+}
+
+func unknownTypeErr(typ string) error {
+	return fmt.Errorf("unknown runner type %q (expected \"local\" or \"voxbox\")", typ)
+}
+
+// run executes name with the given args, wiring through the standard streams. A
+// non-zero child exit is propagated verbatim via os.Exit; a failure to start
+// the command is returned as an error.
+func run(name string, args []string) error {
+	cmd := execCommand(name, args...)
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr

--- a/internal/bundle/bundle_test.go
+++ b/internal/bundle/bundle_test.go
@@ -78,7 +78,7 @@ func TestRunBundle_SuccessReturnsNilAndDoesNotExit(t *testing.T) {
 		func(int) { exitCalled = true },
 	)
 
-	if err := RunBundle([]string{"exec", "rake", "spec"}); err != nil {
+	if err := RunBundle(Runner{}, []string{"exec", "rake", "spec"}); err != nil {
 		t.Fatalf("expected nil error on clean exit, got %v", err)
 	}
 	if exitCalled {
@@ -101,7 +101,7 @@ func TestRunBundle_PropagatesChildExitCode(t *testing.T) {
 
 			// RunBundle returns normally here only because our fake osExit
 			// doesn't terminate; in production os.Exit would not return.
-			_ = RunBundle([]string{"exec", "rake", "validate"})
+			_ = RunBundle(Runner{}, []string{"exec", "rake", "validate"})
 
 			if !gotCalled {
 				t.Fatalf("expected osExit to be called for exit code %d", code)
@@ -128,7 +128,7 @@ func TestRunBundle_StartFailureReturnsErrorNotExit(t *testing.T) {
 		func(int) { exitCalled = true },
 	)
 
-	err := RunBundle([]string{"exec", "msync", "update"})
+	err := RunBundle(Runner{}, []string{"exec", "msync", "update"})
 	if err == nil {
 		t.Fatal("expected an error when the command cannot start, got nil")
 	}
@@ -172,7 +172,7 @@ func TestRunBundle_PassesArgsVerbatim(t *testing.T) {
 				func(int) {},
 			)
 
-			_ = RunBundle(args)
+			_ = RunBundle(Runner{}, args)
 
 			gotParts := []string{}
 			if captured != "" {
@@ -204,8 +204,146 @@ func TestRunBundle_AlwaysInvokesBundle(t *testing.T) {
 		func(int) {},
 	)
 
-	_ = RunBundle([]string{"exec", "rake", "spec"})
+	_ = RunBundle(Runner{}, []string{"exec", "rake", "spec"})
 	if gotName != "bundle" {
 		t.Fatalf("expected command name %q, got %q", "bundle", gotName)
 	}
+}
+
+// --- Runner resolution -----------------------------------------------------
+
+// withGetwd swaps the osGetwd seam so the container runner sees a deterministic
+// module root, restoring it afterward.
+func withGetwd(t *testing.T, fn func() (string, error)) {
+	t.Helper()
+	orig := osGetwd
+	osGetwd = fn
+	t.Cleanup(func() { osGetwd = orig })
+}
+
+// The local runner (zero value and explicit "local") must invoke the host's
+// bundle directly. Rake tasks become `bundle exec rake <tasks>`; raw bundle
+// args pass through untouched. Neither path consults osGetwd.
+func TestRunner_LocalResolves(t *testing.T) {
+	for _, typ := range []string{"", "local"} {
+		t.Run("type="+typ, func(t *testing.T) {
+			withGetwd(t, func() (string, error) {
+				t.Fatal("local runner must not consult the working directory")
+				return "", nil
+			})
+
+			name, args, err := Runner{Type: typ}.resolveRake([]string{"spec"})
+			if err != nil {
+				t.Fatalf("resolveRake: unexpected error: %v", err)
+			}
+			if name != "bundle" {
+				t.Fatalf("resolveRake command: got %q, want %q", name, "bundle")
+			}
+			if want := []string{"exec", "rake", "spec"}; !equal(args, want) {
+				t.Fatalf("resolveRake args mismatch:\n got  %#v\n want %#v", args, want)
+			}
+
+			name, args, err = Runner{Type: typ}.resolveBundle([]string{"exec", "msync", "update"})
+			if err != nil {
+				t.Fatalf("resolveBundle: unexpected error: %v", err)
+			}
+			if name != "bundle" {
+				t.Fatalf("resolveBundle command: got %q, want %q", name, "bundle")
+			}
+			if want := []string{"exec", "msync", "update"}; !equal(args, want) {
+				t.Fatalf("resolveBundle args mismatch:\n got  %#v\n want %#v", args, want)
+			}
+		})
+	}
+}
+
+// A voxbox rake task relies on the image's rake entrypoint, so the task names
+// are passed as the bare container command (no `bundle exec rake` prefix, no
+// --entrypoint override). The module is mounted at /repo.
+func TestRunner_VoxboxRakeInvocation(t *testing.T) {
+	withGetwd(t, func() (string, error) { return "/home/user/mymodule", nil })
+
+	name, args, err := Runner{Type: "voxbox"}.resolveRake([]string{"validate", "lint"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if name != defaultEngine {
+		t.Fatalf("expected engine %q, got %q", defaultEngine, name)
+	}
+	want := []string{
+		"run", "--rm", "-i",
+		"-v", "/home/user/mymodule:/repo:Z",
+		"-w", "/repo",
+		defaultImage,
+		"validate", "lint",
+	}
+	if !equal(args, want) {
+		t.Fatalf("container argv mismatch:\n got  %#v\n want %#v", args, want)
+	}
+}
+
+// A voxbox raw bundle command must override the image's rake entrypoint back to
+// `bundle` (e.g. for msync, which is not a rake task). Custom engine and image
+// must be honoured verbatim; "container" is an alias for "voxbox".
+func TestRunner_VoxboxBundleInvocation(t *testing.T) {
+	withGetwd(t, func() (string, error) { return "/repo/path", nil })
+
+	name, args, err := Runner{
+		Type:   "container",
+		Engine: "podman",
+		Image:  "localhost/voxbox:dev",
+	}.resolveBundle([]string{"exec", "msync", "update"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if name != "podman" {
+		t.Fatalf("expected engine %q, got %q", "podman", name)
+	}
+	want := []string{
+		"run", "--rm", "-i",
+		"-v", "/repo/path:/repo:Z",
+		"-w", "/repo",
+		"--entrypoint", "bundle",
+		"localhost/voxbox:dev",
+		"exec", "msync", "update",
+	}
+	if !equal(args, want) {
+		t.Fatalf("container argv mismatch:\n got  %#v\n want %#v", args, want)
+	}
+}
+
+// An unrecognised runner type must be a hard error on both paths, not a silent
+// fallback to the local bundle (which would defeat opting into a container).
+func TestRunner_UnknownTypeErrors(t *testing.T) {
+	if _, _, err := (Runner{Type: "nope"}).resolveRake([]string{"spec"}); err == nil {
+		t.Fatal("resolveRake: expected an error for an unknown runner type, got nil")
+	}
+	if _, _, err := (Runner{Type: "nope"}).resolveBundle([]string{"exec", "msync", "update"}); err == nil {
+		t.Fatal("resolveBundle: expected an error for an unknown runner type, got nil")
+	}
+}
+
+// If the working directory can't be determined, the container runner must
+// surface that as an error rather than mounting a bogus path.
+func TestRunner_VoxboxGetwdFailureErrors(t *testing.T) {
+	withGetwd(t, func() (string, error) { return "", fmt.Errorf("boom") })
+
+	if _, _, err := (Runner{Type: "voxbox"}).resolveRake([]string{"spec"}); err == nil {
+		t.Fatal("resolveRake: expected an error when the working directory is unavailable, got nil")
+	}
+	if _, _, err := (Runner{Type: "voxbox"}).resolveBundle([]string{"exec", "msync", "update"}); err == nil {
+		t.Fatal("resolveBundle: expected an error when the working directory is unavailable, got nil")
+	}
+}
+
+func equal(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -4,17 +4,37 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
 )
 
+// Default values for the container runner. Exposed so callers and tests can
+// refer to them without duplicating the literals.
+const (
+	DefaultRunnerType   = "local"
+	DefaultRunnerEngine = "docker"
+	DefaultRunnerImage  = "ghcr.io/voxpupuli/voxbox:latest"
+)
+
 type Config struct {
-	ForgeUsername string `mapstructure:"forge_username"`
-	Author        string `mapstructure:"author"`
-	License       string `mapstructure:"license"`
-	ForgeToken    string `mapstructure:"forge_token"`
-	TemplateDir   string `mapstructure:"template_dir"`
+	ForgeUsername string       `mapstructure:"forge_username"`
+	Author        string       `mapstructure:"author"`
+	License       string       `mapstructure:"license"`
+	ForgeToken    string       `mapstructure:"forge_token"`
+	TemplateDir   string       `mapstructure:"template_dir"`
+	Runner        RunnerConfig `mapstructure:"runner"`
+}
+
+// RunnerConfig controls how the bundle-backed commands (update/test/validate)
+// are executed. With Type "local" jig invokes the host's `bundle` directly;
+// with "voxbox" it runs `bundle` inside the voxbox container so no system-wide
+// Ruby/bundler install is required (e.g. on Windows).
+type RunnerConfig struct {
+	Type   string `mapstructure:"type"`
+	Engine string `mapstructure:"engine"`
+	Image  string `mapstructure:"image"`
 }
 
 func Load(path string, logger *logrus.Logger) (Config, error) {
@@ -27,10 +47,22 @@ func Load(path string, logger *logrus.Logger) (Config, error) {
 		logger.Debugf("config path not provided, using default path: %s", path)
 	}
 
-	viper.SetConfigFile(path)
-	viper.SetEnvPrefix("JIG")
-	viper.AutomaticEnv()
-	if err := viper.ReadInConfig(); err != nil {
+	// A fresh instance keeps loads isolated from each other (and from any
+	// global viper state), which matters for both repeated calls and tests.
+	v := viper.New()
+	v.SetConfigFile(path)
+	v.SetEnvPrefix("JIG")
+	// Map nested keys onto env vars, e.g. runner.type -> JIG_RUNNER_TYPE.
+	v.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
+	v.AutomaticEnv()
+
+	// Defaults double as key registration so AutomaticEnv overrides are picked
+	// up by Unmarshal even when the keys are absent from the config file.
+	v.SetDefault("runner.type", DefaultRunnerType)
+	v.SetDefault("runner.engine", DefaultRunnerEngine)
+	v.SetDefault("runner.image", DefaultRunnerImage)
+
+	if err := v.ReadInConfig(); err != nil {
 		if !os.IsNotExist(err) {
 			return Config{}, err
 		}
@@ -40,7 +72,7 @@ func Load(path string, logger *logrus.Logger) (Config, error) {
 	}
 
 	config := Config{}
-	err := viper.Unmarshal(&config)
+	err := v.Unmarshal(&config)
 	if err != nil {
 		return Config{}, err
 	}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+package config
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+)
+
+// quietLogger returns a logger that discards output so tests stay silent.
+func quietLogger() *logrus.Logger {
+	l := logrus.New()
+	l.SetOutput(io.Discard)
+	return l
+}
+
+// writeConfig writes the given TOML into a temp file and returns its path.
+func writeConfig(t *testing.T, body string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "config.toml")
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("writing temp config: %v", err)
+	}
+	return path
+}
+
+// With no config file present, the runner must fall back to the documented
+// defaults (local runner, docker engine, voxbox image).
+func TestLoad_RunnerDefaults(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "does-not-exist.toml")
+
+	cfg, err := Load(path, quietLogger())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.Runner.Type != DefaultRunnerType {
+		t.Errorf("runner type: got %q, want %q", cfg.Runner.Type, DefaultRunnerType)
+	}
+	if cfg.Runner.Engine != DefaultRunnerEngine {
+		t.Errorf("runner engine: got %q, want %q", cfg.Runner.Engine, DefaultRunnerEngine)
+	}
+	if cfg.Runner.Image != DefaultRunnerImage {
+		t.Errorf("runner image: got %q, want %q", cfg.Runner.Image, DefaultRunnerImage)
+	}
+}
+
+// Values in the config file must populate the nested runner struct.
+func TestLoad_RunnerFromFile(t *testing.T) {
+	path := writeConfig(t, `
+forge_username = "avitacco"
+
+[runner]
+type   = "voxbox"
+engine = "podman"
+image  = "localhost/voxbox:dev"
+`)
+
+	cfg, err := Load(path, quietLogger())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.ForgeUsername != "avitacco" {
+		t.Errorf("forge_username: got %q, want %q", cfg.ForgeUsername, "avitacco")
+	}
+	if cfg.Runner.Type != "voxbox" {
+		t.Errorf("runner type: got %q, want %q", cfg.Runner.Type, "voxbox")
+	}
+	if cfg.Runner.Engine != "podman" {
+		t.Errorf("runner engine: got %q, want %q", cfg.Runner.Engine, "podman")
+	}
+	if cfg.Runner.Image != "localhost/voxbox:dev" {
+		t.Errorf("runner image: got %q, want %q", cfg.Runner.Image, "localhost/voxbox:dev")
+	}
+}
+
+// An environment variable must override the config file for nested runner keys
+// (JIG_RUNNER_TYPE -> runner.type). This is the override path ananace's users
+// rely on without a CLI flag.
+func TestLoad_RunnerEnvOverridesFile(t *testing.T) {
+	path := writeConfig(t, `
+[runner]
+type = "local"
+`)
+
+	t.Setenv("JIG_RUNNER_TYPE", "voxbox")
+
+	cfg, err := Load(path, quietLogger())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.Runner.Type != "voxbox" {
+		t.Errorf("runner type: env override not applied, got %q, want %q", cfg.Runner.Type, "voxbox")
+	}
+}
+
+// The env override must also work when the key is absent from the file, since
+// AutomaticEnv only reaches Unmarshal because the defaults register the keys.
+func TestLoad_RunnerEnvOverridesDefault(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "absent.toml")
+
+	t.Setenv("JIG_RUNNER_ENGINE", "podman")
+
+	cfg, err := Load(path, quietLogger())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.Runner.Engine != "podman" {
+		t.Errorf("runner engine: env override not applied, got %q, want %q", cfg.Runner.Engine, "podman")
+	}
+}


### PR DESCRIPTION
The update/test/validate commands shell out to a Ruby toolchain via bundle, which requires a system-wide Ruby/bundler install. This is awkward on Windows. Allow these commands to run inside the voxbox container instead, so the only host dependency is a container engine.

Add a [runner] config section (type/engine/image, overridable via JIG_RUNNER_* env vars). With type = "voxbox", jig mounts the module root at /repo and runs the command in the container.

voxbox is not a generic bundle wrapper: its entrypoint is already `bundle exec rake -f <its Rakefile>`. So rake-based commands (test, validate) pass bare task names through, while update overrides the entrypoint to `bundle` since msync is not a rake task. Model these as two shapes in the bundle package: RunRake and RunBundle.