### PR TITLE
Run validate checks as separate rake tasks and add rubocop support

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,15 +285,28 @@ already exist under `pkg/`. An error is returned if it is not found.
 
 ### `jig validate`
 
-Runs validation and linting against the current module. This is a passthrough
-command that shells out to `bundle exec rake validate lint`, so it requires
-a Ruby toolchain and the module's bundled gems to be installed — or a container
-runner (see [Running through voxbox](#running-through-voxbox)).
+Runs validation checks against the current module. By default this mirrors
+`pdk validate`: syntax (`rake validate`), puppet-lint (`rake lint`) and
+rubocop (`rake rubocop`) all run, each as its own rake invocation. It shells
+out to `bundle exec rake <task>` per check, so it requires a Ruby toolchain
+and the module's bundled gems to be installed — or a container runner (see
+[Running through voxbox](#running-through-voxbox)).
 ```
-jig validate [args...]
+jig validate [flags] [-- args...]
 ```
 
-Any additional arguments are passed through verbatim to the underlying rake
+| Flag | Description |
+| ---- | ----------- |
+| `-s`, `--syntax` | Run syntax checks (`rake validate`) |
+| `-l`, `--lint` | Run puppet-lint checks (`rake lint`) |
+| `-r`, `--rubocop` | Run rubocop checks (`rake rubocop`) |
+
+With no flags all three checks run. Passing one or more flags runs only the
+selected checks, e.g. `jig validate -s` for syntax only or `jig validate -sl`
+to skip rubocop. Checks run in order and stop at the first failure,
+propagating its exit code.
+
+Any arguments after `--` are passed through verbatim to each underlying rake
 invocation.
 
 ### `jig test unit`

--- a/commands/validate.go
+++ b/commands/validate.go
@@ -5,13 +5,54 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// validateTasks maps the selection flags to the rake tasks to run. With no
+// flags set every check runs (mirroring `pdk validate`); setting any flag
+// narrows the run to just the selected checks.
+func validateTasks(syntax, lint, rubocop bool) []string {
+	if !syntax && !lint && !rubocop {
+		return []string{"validate", "lint", "rubocop"}
+	}
+	var tasks []string
+	if syntax {
+		tasks = append(tasks, "validate")
+	}
+	if lint {
+		tasks = append(tasks, "lint")
+	}
+	if rubocop {
+		tasks = append(tasks, "rubocop")
+	}
+	return tasks
+}
+
 func (a *App) validateCmd() *cobra.Command {
-	return &cobra.Command{
-		Use:                "validate",
-		Short:              "Run rake validate and lint through bundle",
-		DisableFlagParsing: true,
+	var syntax, lint, rubocop bool
+
+	cmd := &cobra.Command{
+		Use:   "validate",
+		Short: "Run rake validate, lint and rubocop through bundle",
+		Long: `Run validation checks against the current module.
+
+By default all checks run: syntax (rake validate), puppet-lint (rake lint)
+and rubocop (rake rubocop). Pass one or more selection flags to run only
+those checks. Arguments after -- are forwarded to each rake invocation.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return a.runRake(append([]string{"validate", "lint"}, args...))
+			// One rake invocation per task: the voxbox entrypoint only honours
+			// a single task per run (#64), and locally the behaviour is the
+			// same. A failing task exits with the child's code, so later tasks
+			// only run once the earlier ones pass.
+			for _, task := range validateTasks(syntax, lint, rubocop) {
+				if err := a.runRake(append([]string{task}, args...)); err != nil {
+					return err
+				}
+			}
+			return nil
 		},
 	}
+
+	cmd.Flags().BoolVarP(&syntax, "syntax", "s", false, "run syntax checks (rake validate)")
+	cmd.Flags().BoolVarP(&lint, "lint", "l", false, "run puppet-lint checks (rake lint)")
+	cmd.Flags().BoolVarP(&rubocop, "rubocop", "r", false, "run rubocop checks (rake rubocop)")
+
+	return cmd
 }

--- a/commands/validate_test.go
+++ b/commands/validate_test.go
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+package commands
+
+import (
+	"strings"
+	"testing"
+)
+
+// No selection flags means every check runs, in the fixed syntax -> lint ->
+// rubocop order (mirroring `pdk validate`). Any combination of flags narrows
+// the run to exactly the selected checks, preserving that order.
+func TestValidateTasks(t *testing.T) {
+	cases := []struct {
+		syntax, lint, rubocop bool
+		want                  []string
+	}{
+		{false, false, false, []string{"validate", "lint", "rubocop"}},
+		{true, false, false, []string{"validate"}},
+		{false, true, false, []string{"lint"}},
+		{false, false, true, []string{"rubocop"}},
+		{true, true, false, []string{"validate", "lint"}},
+		{true, false, true, []string{"validate", "rubocop"}},
+		{false, true, true, []string{"lint", "rubocop"}},
+		{true, true, true, []string{"validate", "lint", "rubocop"}},
+	}
+
+	for _, c := range cases {
+		name := strings.Join(c.want, "+")
+		t.Run(name, func(t *testing.T) {
+			got := validateTasks(c.syntax, c.lint, c.rubocop)
+			if len(got) != len(c.want) {
+				t.Fatalf("validateTasks(%v, %v, %v) = %#v, want %#v",
+					c.syntax, c.lint, c.rubocop, got, c.want)
+			}
+			for i := range c.want {
+				if got[i] != c.want[i] {
+					t.Fatalf("validateTasks(%v, %v, %v) = %#v, want %#v",
+						c.syntax, c.lint, c.rubocop, got, c.want)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
`jig validate` previously passed both tasks to a single rake invocation (`bundle exec rake validate lint`). The voxbox container entrypoint only honours one task per run, so lint checks silently never executed there.

Each check now runs as its own rake invocation, and rubocop joins the default set to mirror `pdk validate`: bare `jig validate` runs syntax (rake validate), puppet-lint (rake lint), and rubocop (rake rubocop) in order, stopping at the first failure and propagating its exit code.

New selection flags narrow the run to specific checks:

  -s, --syntax    syntax checks only (rake validate)
  -l, --lint      puppet-lint checks only (rake lint)
  -r, --rubocop   rubocop checks only (rake rubocop)

Flags can be combined (e.g. `jig validate -sl`). Since the command now parses flags, passthrough arguments to rake go after `--` (e.g. `jig validate -s -- --trace`) instead of being forwarded implicitly.

Fixes #64
Fixes #65