### PR TITLE
Add command for convert

### DIFF
--- a/commands/convert.go
+++ b/commands/convert.go
@@ -1,0 +1,32 @@
+package commands
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+	"github.com/voxpupuli/jig/internal/scaffold"
+)
+
+func (a *App) convertCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "convert",
+		Short: "Update Gemfile, Rakefile and spec_helper.rb in an existing module to be usable with voxbox and Vox Pupuli tooling",
+		Long:  `Reads the templates and overwrites Gemfile, Rakefile uand spec/spec_helper.rb in the actual Puppet module.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cwd, err := os.Getwd()
+			if err != nil {
+				return fmt.Errorf("failed to get working directory: %w", err)
+			}
+
+			err = scaffold.ConvertModule(cwd)
+			if err != nil {
+				return fmt.Errorf("convert failed: %w", err)
+			}
+
+			fmt.Println("convert successful: Gemfile, Rakefile, spec/spec_helper.rb")
+			return nil
+		},
+	}
+}
+

--- a/commands/convert.go
+++ b/commands/convert.go
@@ -29,4 +29,3 @@ func (a *App) convertCmd() *cobra.Command {
 		},
 	}
 }
-

--- a/commands/convert.go
+++ b/commands/convert.go
@@ -12,7 +12,7 @@ func (a *App) convertCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "convert",
 		Short: "Update Gemfile, Rakefile and spec_helper.rb in an existing module to be usable with voxbox and Vox Pupuli tooling",
-		Long:  `Reads the templates and overwrites Gemfile, Rakefile uand spec/spec_helper.rb in the actual Puppet module.`,
+		Long:  `Reads the templates and overwrites Gemfile, Rakefile and spec/spec_helper.rb in the actual Puppet module.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cwd, err := os.Getwd()
 			if err != nil {

--- a/commands/root.go
+++ b/commands/root.go
@@ -45,6 +45,7 @@ func Execute() error {
 	rootCmd.AddCommand(app.updateCmd())
 	rootCmd.AddCommand(app.validateCmd())
 	rootCmd.AddCommand(app.testCmd())
+	rootCmd.AddCommand(app.convertCmd())
 
 	return rootCmd.Execute()
 }

--- a/internal/scaffold/convert.go
+++ b/internal/scaffold/convert.go
@@ -10,7 +10,7 @@ import (
 
 func ConvertModule(targetDir string) error {
 	if _, err := os.Stat(filepath.Join(targetDir, "metadata.json")); os.IsNotExist(err) {
-		return fmt.Errorf("no metadata.json found. the jig convert commnd must be executed from the module base.")
+		return fmt.Errorf("metadata.json not found; the convert command must be executed from the module base directory.")
 	}
 
 	filesToUpdate := []struct {

--- a/internal/scaffold/convert.go
+++ b/internal/scaffold/convert.go
@@ -1,0 +1,47 @@
+package scaffold
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	
+	"github.com/voxpupuli/jig/internal/template" 
+)
+
+func ConvertModule(targetDir string) error {
+	if _, err := os.Stat(filepath.Join(targetDir, "metadata.json")); os.IsNotExist(err) {
+		return fmt.Errorf("no metadata.json found. the jig convert commnd must be executed from the module base.")
+	}
+
+	filesToUpdate := []struct {
+		TemplatePath string
+		DestPath     string
+	}{
+		{TemplatePath: "module/Gemfile", DestPath: "Gemfile"},
+		{TemplatePath: "module/Rakefile", DestPath: "Rakefile"},
+		{TemplatePath: "module/spec/spec_helper.rb", DestPath: filepath.Join("spec", "spec_helper.rb")},
+	}
+
+	specDir := filepath.Join(targetDir, "spec")
+	if err := os.MkdirAll(specDir, 0755); err != nil {
+		return fmt.Errorf("Error creating spec directory: %w", err)
+	}
+
+	renderer := template.NewRenderer() 
+
+	for _, f := range filesToUpdate {
+		fullDestPath := filepath.Join(targetDir, f.DestPath)
+
+		content, err := renderer.Render(f.TemplatePath, nil)
+		if err != nil {
+			return fmt.Errorf("Error while parsing template %s: %w", f.TemplatePath, err)
+		}
+
+		err = os.WriteFile(fullDestPath, []byte(content), 0644)
+		if err != nil {
+			return fmt.Errorf("Error writing file %s: %w", fullDestPath, err)
+		}
+	}
+
+	return nil
+}

--- a/internal/scaffold/convert.go
+++ b/internal/scaffold/convert.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	
-	"github.com/voxpupuli/jig/internal/template" 
+
+	"github.com/voxpupuli/jig/internal/template"
 )
 
 func ConvertModule(targetDir string) error {
@@ -27,7 +27,7 @@ func ConvertModule(targetDir string) error {
 		return fmt.Errorf("Error creating spec directory: %w", err)
 	}
 
-	renderer := template.NewRenderer() 
+	renderer := template.NewRenderer()
 
 	for _, f := range filesToUpdate {
 		fullDestPath := filepath.Join(targetDir, f.DestPath)

--- a/internal/scaffold/convert_test.go
+++ b/internal/scaffold/convert_test.go
@@ -28,7 +28,7 @@ func TestConvertModule(t *testing.T) {
 
 	for _, file := range expectedFiles {
 		fullPath := filepath.Join(tmpDir, file)
-		
+
 		info, err := os.Stat(fullPath)
 		if os.IsNotExist(err) {
 			t.Errorf("Expected file was not created: %s", file)

--- a/internal/scaffold/convert_test.go
+++ b/internal/scaffold/convert_test.go
@@ -1,0 +1,55 @@
+package scaffold
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestConvertModule(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	metadataPath := filepath.Join(tmpDir, "metadata.json")
+	err := os.WriteFile(metadataPath, []byte(`{"name": "test-module", "version": "0.1.0"}`), 0644)
+	if err != nil {
+		t.Fatalf("Error while generating the mock metadata.json: %v", err)
+	}
+
+	err = ConvertModule(tmpDir)
+	if err != nil {
+		t.Fatalf("ConvertModule failed unexpected: %v", err)
+	}
+
+	expectedFiles := []string{
+		"Gemfile",
+		"Rakefile",
+		filepath.Join("spec", "spec_helper.rb"),
+	}
+
+	for _, file := range expectedFiles {
+		fullPath := filepath.Join(tmpDir, file)
+		
+		info, err := os.Stat(fullPath)
+		if os.IsNotExist(err) {
+			t.Errorf("Expected file was not created: %s", file)
+			continue
+		}
+		if err != nil {
+			t.Errorf("Error while checking file %s: %v", file, err)
+			continue
+		}
+
+		if info.Size() == 0 {
+			t.Errorf("File %s was created, but empty", file)
+		}
+	}
+}
+
+func TestConvertModule_MissingMetadata(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	err := ConvertModule(tmpDir)
+	if err == nil {
+		t.Error("Expected an error, as metadata.json is missing, but convertModule ran successfully")
+	}
+}

--- a/internal/template/templates/module/spec/spec_helper.rb
+++ b/internal/template/templates/module/spec/spec_helper.rb
@@ -18,4 +18,7 @@ if File.exist?(File.join(__dir__, 'default_module_facts.yml'))
     add_custom_fact name.to_sym, value
   end
 end
+
+require 'spec_helper_local' if File.file?(File.join(File.dirname(__FILE__), 'spec_helper_local.rb'))
+
 Dir['./spec/support/spec/**/*.rb'].sort.each { |f| require f }


### PR DESCRIPTION
Many people have used PDK in the past to write modules internally. PDK has a completely different Gemfile, Rakefile and spec/spec_helper.rb

This PR adds the possibility to convert these three files by running `jig convert` inside a module root path.