### PR TITLE
Removing pdk-version from metadata

### DIFF
--- a/internal/build/build_test.go
+++ b/internal/build/build_test.go
@@ -70,7 +70,6 @@ func writeTestMetadata(t *testing.T, dir, forgeUser, moduleName, version string)
 		"requirements":            []any{},
 		"operatingsystem_support": []any{},
 		"tags":                    []any{},
-		"pdk-version":             "3.4.0",
 	}
 	metaData, err := json.Marshal(meta)
 	if err != nil {
@@ -317,7 +316,6 @@ func TestDoBuild_InvalidMetadata(t *testing.T) {
 		"requirements":            []any{},
 		"operatingsystem_support": []any{},
 		"tags":                    []any{},
-		"pdk-version":             "3.4.0",
 	}
 	metaData, err := json.Marshal(meta)
 	if err != nil {

--- a/internal/module/metadata.go
+++ b/internal/module/metadata.go
@@ -21,7 +21,6 @@ type Metadata struct {
 	Requirements    []Requirement     `json:"requirements"`
 	OperatingSystem []OperatingSystem `json:"operatingsystem_support"`
 	Tags            []string          `json:"tags"`
-	PdkVersion      string            `json:"pdk-version"`
 	// TemplateURL, TemplateRef, and TemplateCommit were written by jig 1.x
 	// to record which template repository the module was scaffolded from.
 	// jig 2.x records template provenance in jig.toml instead and does not
@@ -69,7 +68,6 @@ func NewMetadata(name string, forgeUser string, author string) Metadata {
 		},
 		OperatingSystem: []OperatingSystem{},
 		Tags:            []string{},
-		PdkVersion:      "3.4.0",
 	}
 }
 

--- a/internal/module/metadata_test.go
+++ b/internal/module/metadata_test.go
@@ -92,8 +92,7 @@ func TestReadMetadata(t *testing.T) {
 			"dependencies": [],
 			"requirements": [],
 			"operatingsystem_support": [],
-			"tags": [],
-			"pdk-version": "3.4.0"
+			"tags": []
 		}`
 		if err := os.WriteFile(path, []byte(content), 0644); err != nil {
 			t.Fatal(err)

--- a/internal/scaffold/helpers_test.go
+++ b/internal/scaffold/helpers_test.go
@@ -51,7 +51,6 @@ func makeModuleDir(t *testing.T, forgeUser, moduleName string) string {
 		"requirements":            []any{},
 		"operatingsystem_support": []any{},
 		"tags":                    []any{},
-		"pdk-version":             "3.4.0",
 	}
 	data, err := json.Marshal(meta)
 	if err != nil {


### PR DESCRIPTION
I am removing the pdk-version from the metadata.json file because this project no longer aims to simply a be a drop-in replacement for PDK.

This resolves #83 