### PR TITLE
Update module path to github.com/voxpupuli/jig/v2

### DIFF
--- a/commands/app.go
+++ b/commands/app.go
@@ -3,8 +3,8 @@ package commands
 
 import (
 	"github.com/sirupsen/logrus"
-	"github.com/voxpupuli/jig/internal/bundle"
-	"github.com/voxpupuli/jig/internal/config"
+	"github.com/voxpupuli/jig/v2/internal/bundle"
+	"github.com/voxpupuli/jig/v2/internal/config"
 )
 
 type App struct {

--- a/commands/build.go
+++ b/commands/build.go
@@ -6,7 +6,7 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
-	"github.com/voxpupuli/jig/internal/build"
+	"github.com/voxpupuli/jig/v2/internal/build"
 )
 
 func (a *App) buildCmd() *cobra.Command {

--- a/commands/convert.go
+++ b/commands/convert.go
@@ -5,7 +5,7 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
-	"github.com/voxpupuli/jig/internal/scaffold"
+	"github.com/voxpupuli/jig/v2/internal/scaffold"
 )
 
 func (a *App) convertCmd() *cobra.Command {

--- a/commands/new.go
+++ b/commands/new.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
-	"github.com/voxpupuli/jig/internal/scaffold"
+	"github.com/voxpupuli/jig/v2/internal/scaffold"
 )
 
 func (a *App) newCmd() *cobra.Command {

--- a/commands/release.go
+++ b/commands/release.go
@@ -6,8 +6,8 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
-	"github.com/voxpupuli/jig/internal/forge"
-	"github.com/voxpupuli/jig/internal/release"
+	"github.com/voxpupuli/jig/v2/internal/forge"
+	"github.com/voxpupuli/jig/v2/internal/release"
 )
 
 func (a *App) releaseCmd() *cobra.Command {

--- a/commands/renew.go
+++ b/commands/renew.go
@@ -6,8 +6,8 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
-	"github.com/voxpupuli/jig/internal/config"
-	"github.com/voxpupuli/jig/internal/scaffold"
+	"github.com/voxpupuli/jig/v2/internal/config"
+	"github.com/voxpupuli/jig/v2/internal/scaffold"
 )
 
 func (a *App) renewCmd() *cobra.Command {

--- a/commands/renew_test.go
+++ b/commands/renew_test.go
@@ -10,8 +10,8 @@ import (
 
 	git "github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing/object"
-	"github.com/voxpupuli/jig/internal/config"
-	"github.com/voxpupuli/jig/internal/module"
+	"github.com/voxpupuli/jig/v2/internal/config"
+	"github.com/voxpupuli/jig/v2/internal/module"
 )
 
 // moduleTemplateRepo builds a local git repository holding a module template

--- a/commands/root.go
+++ b/commands/root.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-	"github.com/voxpupuli/jig/internal/config"
+	"github.com/voxpupuli/jig/v2/internal/config"
 )
 
 func Execute() error {

--- a/commands/templates.go
+++ b/commands/templates.go
@@ -8,8 +8,8 @@ import (
 	"path/filepath"
 
 	"github.com/spf13/cobra"
-	"github.com/voxpupuli/jig/internal/scaffold"
-	"github.com/voxpupuli/jig/internal/template"
+	"github.com/voxpupuli/jig/v2/internal/scaffold"
+	"github.com/voxpupuli/jig/v2/internal/template"
 )
 
 func (a *App) templatesCmd() *cobra.Command {

--- a/commands/templates_test.go
+++ b/commands/templates_test.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/voxpupuli/jig/internal/config"
+	"github.com/voxpupuli/jig/v2/internal/config"
 )
 
 // runTemplatesResolve executes `jig templates resolve <name>` with the given

--- a/commands/templatesource.go
+++ b/commands/templatesource.go
@@ -8,9 +8,9 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
-	"github.com/voxpupuli/jig/internal/config"
-	"github.com/voxpupuli/jig/internal/module"
-	"github.com/voxpupuli/jig/internal/remote"
+	"github.com/voxpupuli/jig/v2/internal/config"
+	"github.com/voxpupuli/jig/v2/internal/module"
+	"github.com/voxpupuli/jig/v2/internal/remote"
 )
 
 // templateSource is a resolved template location: a local directory (possibly

--- a/commands/templatesource_test.go
+++ b/commands/templatesource_test.go
@@ -13,8 +13,8 @@ import (
 	"github.com/go-git/go-git/v5/plumbing/object"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-	"github.com/voxpupuli/jig/internal/config"
-	"github.com/voxpupuli/jig/internal/module"
+	"github.com/voxpupuli/jig/v2/internal/config"
+	"github.com/voxpupuli/jig/v2/internal/module"
 )
 
 func testApp(cfg config.Config) *App {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/voxpupuli/jig
+module github.com/voxpupuli/jig/v2
 
 go 1.25.5
 

--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -11,9 +11,9 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/voxpupuli/jig/internal/config"
-	"github.com/voxpupuli/jig/internal/module"
-	"github.com/voxpupuli/jig/internal/scaffold"
+	"github.com/voxpupuli/jig/v2/internal/config"
+	"github.com/voxpupuli/jig/v2/internal/module"
+	"github.com/voxpupuli/jig/v2/internal/scaffold"
 )
 
 func DoBuild(dir string) error {

--- a/internal/build/build_test.go
+++ b/internal/build/build_test.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/voxpupuli/jig/internal/config"
+	"github.com/voxpupuli/jig/v2/internal/config"
 )
 
 // makeBuildDir creates a minimal but realistic module directory suitable for

--- a/internal/build/filter.go
+++ b/internal/build/filter.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 
 	gogitignore "github.com/go-git/go-git/v5/plumbing/format/gitignore"
-	"github.com/voxpupuli/jig/internal/config"
+	"github.com/voxpupuli/jig/v2/internal/config"
 )
 
 // specAllowlist is the set of files permitted in a published module per the

--- a/internal/release/release.go
+++ b/internal/release/release.go
@@ -7,10 +7,10 @@ import (
 	"path/filepath"
 	"regexp"
 
-	"github.com/voxpupuli/jig/internal/build"
-	"github.com/voxpupuli/jig/internal/forge"
-	"github.com/voxpupuli/jig/internal/module"
-	"github.com/voxpupuli/jig/internal/scaffold"
+	"github.com/voxpupuli/jig/v2/internal/build"
+	"github.com/voxpupuli/jig/v2/internal/forge"
+	"github.com/voxpupuli/jig/v2/internal/module"
+	"github.com/voxpupuli/jig/v2/internal/scaffold"
 )
 
 // Options controls the behaviour of DoRelease.

--- a/internal/scaffold/convert.go
+++ b/internal/scaffold/convert.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/voxpupuli/jig/internal/template"
+	"github.com/voxpupuli/jig/v2/internal/template"
 )
 
 func ConvertModule(targetDir string) error {

--- a/internal/scaffold/module.go
+++ b/internal/scaffold/module.go
@@ -6,8 +6,8 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/voxpupuli/jig/internal/config"
-	"github.com/voxpupuli/jig/internal/module"
+	"github.com/voxpupuli/jig/v2/internal/config"
+	"github.com/voxpupuli/jig/v2/internal/module"
 )
 
 func NewModule(opts Options) error {

--- a/internal/scaffold/module_test.go
+++ b/internal/scaffold/module_test.go
@@ -6,7 +6,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/voxpupuli/jig/internal/config"
+	"github.com/voxpupuli/jig/v2/internal/config"
 )
 
 func TestNewModule(t *testing.T) {

--- a/internal/scaffold/renew.go
+++ b/internal/scaffold/renew.go
@@ -10,7 +10,7 @@ import (
 
 	gogitignore "github.com/go-git/go-git/v5/plumbing/format/gitignore"
 	"github.com/sergi/go-diff/diffmatchpatch"
-	"github.com/voxpupuli/jig/internal/config"
+	"github.com/voxpupuli/jig/v2/internal/config"
 )
 
 // RenewOptions controls Renew. Paths is the [renew] allowlist from jig.toml:

--- a/internal/scaffold/scaffold.go
+++ b/internal/scaffold/scaffold.go
@@ -8,8 +8,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/voxpupuli/jig/internal/module"
-	"github.com/voxpupuli/jig/internal/template"
+	"github.com/voxpupuli/jig/v2/internal/module"
+	"github.com/voxpupuli/jig/v2/internal/template"
 )
 
 // Renderer is the interface satisfied by *template.Renderer. Declared here

--- a/main.go
+++ b/main.go
@@ -4,7 +4,7 @@ package main
 import (
 	"os"
 
-	"github.com/voxpupuli/jig/commands"
+	"github.com/voxpupuli/jig/v2/commands"
 )
 
 func main() {


### PR DESCRIPTION
Project's major version was bumped to `v2`, but `go.mod` wasn't updated.

As a result `go install` is broken:

`@latest` installs `v1.5.0`:

```bash
❯ go install github.com/voxpupuli/jig@latest
go: downloading github.com/voxpupuli/jig v1.5.0
go: downloading golang.org/x/sys v0.45.0
go: downloading golang.org/x/net v0.55.0
go: downloading golang.org/x/text v0.37.0
```

`v2.2.1` results in error:

```bash
❯ go install github.com/voxpupuli/jig@v2.2.1
go: github.com/voxpupuli/jig@v2.2.1: github.com/voxpupuli/jig@v2.2.1: invalid version: module contains a go.mod file, so module path must match major version ("github.com/voxpupuli/jig/v2")
```

This PR bumps package version in `go.mod` and in internal imports.

All is done according to golang documentation: https://go.dev/doc/modules/major-version